### PR TITLE
fix: WP-403 - dont pass unknown props to element <a>

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,19 +55,18 @@ export default function Button(props) {
   }
   const LinkComponent = props.LinkComponent || 'a';
   linkProps.onClick = onClick;
-  const filteredProps = {};
-  filteredProps.className = [ 'link-button' ].concat(extraClassNames).join(' ');
-  filteredProps.href = linkProps.href;
-  filteredProps.target = linkProps.target;
+  linkProps.className = [ 'link-button' ].concat(extraClassNames).join(' ');
+  Reflect.deleteProperty(linkProps, 'unstyled');
+  Reflect.deleteProperty(linkProps, 'internal');
   if (i13nModel) {
     const I13nLink = createI13nNode(LinkComponent, {
       isLeafNode: true,
       bindClickEvent: true,
       follow: true,
     });
-    return (<I13nLink {...filteredProps}>{content}</I13nLink>);
+    return (<I13nLink {...linkProps}>{content}</I13nLink>);
   }
-  return (<LinkComponent {...filteredProps}>{content}</LinkComponent>);
+  return (<LinkComponent {...linkProps}>{content}</LinkComponent>);
 }
 
 Button.propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -55,17 +55,19 @@ export default function Button(props) {
   }
   const LinkComponent = props.LinkComponent || 'a';
   linkProps.onClick = onClick;
-  linkProps.className = [ 'link-button' ].concat(extraClassNames).join(' ');
-
+  const filteredProps = {};
+  filteredProps.className = [ 'link-button' ].concat(extraClassNames).join(' ');
+  filteredProps.href = linkProps.href;
+  filteredProps.target = linkProps.target;
   if (i13nModel) {
     const I13nLink = createI13nNode(LinkComponent, {
       isLeafNode: true,
       bindClickEvent: true,
       follow: true,
     });
-    return (<I13nLink {...linkProps}>{content}</I13nLink>);
+    return (<I13nLink {...filteredProps}>{content}</I13nLink>);
   }
-  return (<LinkComponent {...linkProps}>{content}</LinkComponent>);
+  return (<LinkComponent {...filteredProps}>{content}</LinkComponent>);
 }
 
 Button.propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,6 @@ export default function Button(props) {
   linkProps.onClick = onClick;
   linkProps.className = [ 'link-button' ].concat(extraClassNames).join(' ');
   Reflect.deleteProperty(linkProps, 'unstyled');
-  Reflect.deleteProperty(linkProps, 'internal');
   if (i13nModel) {
     const I13nLink = createI13nNode(LinkComponent, {
       isLeafNode: true,

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,13 @@ describe('LinkButton', () => {
       .find('a').should.have.className('testing');
     });
 
+    it('does not render unneeded attributes', () => {
+      mount(<LinkButton />)
+      .find('a').should.not.have.attr('unstyled');
+      mount(<LinkButton />)
+      .find('a').should.not.have.attr('internal');
+    });
+
   });
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -52,8 +52,6 @@ describe('LinkButton', () => {
     it('does not render unneeded attributes', () => {
       mount(<LinkButton />)
       .find('a').should.not.have.attr('unstyled');
-      mount(<LinkButton />)
-      .find('a').should.not.have.attr('internal');
     });
 
   });


### PR DESCRIPTION
This is a fix for a warning regarding unknown props passed to the element <a> in the component-link-button. This change is part of the the task https://jira.economist.com/browse/WP-403